### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,4 +1,6 @@
 name: PR Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/0x53A/UAS-SigVer/security/code-scanning/2](https://github.com/0x53A/UAS-SigVer/security/code-scanning/2)

The best way to fix the problem is to explicitly add a `permissions` block to the workflow, either at the root level (applies to all jobs) or per job. For this workflow, adding it at the root is sufficient and idiomatic. The minimal required permission is `contents: read`, since the workflow only checks out and builds code—it does not perform PR labeling, comment posting, or artifact uploads requiring additional privileges. The change should go after the `name` field and before `on` (per GitHub Actions YAML conventions), so between lines 1 and 3.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
